### PR TITLE
Update database.mdx

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -149,12 +149,12 @@ The MongoDB adapter expects a mongodb client instance and a database name. The a
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
 import { MongoClient } from "mongodb";
-import { mongoAdapter } from "better-auth/adapters/mongodb";
+import { mongodbAdapter } from "better-auth/adapters/mongodb";
 
 const client = new MongoClient("mongodb://localhost:27017");
 
 export const auth = betterAuth({
-    database: mongoAdapter(client)
+    database: mongodbAdapter(client)
 })
 ```
 


### PR DESCRIPTION
Some issues on the mongodb adapter guide.

1. the exported adapter name is mongodbAdapter, not mongoAdapter. 
2. the adapter is not expecting a mongo client, rather a db instance
3. we need type for auth :)

![image](https://github.com/user-attachments/assets/9c930f38-6453-4ffb-9a0e-40d86ec33565)
![image](https://github.com/user-attachments/assets/8c3e8801-1ec9-4878-8fa2-27ff6b8b959e)
![image](https://github.com/user-attachments/assets/a9ccc16a-971f-4974-90f0-ef59810617b6)

